### PR TITLE
nmixer: always use "%s"-style format for printf()-style functions

### DIFF
--- a/nmixer/nmixer.cc
+++ b/nmixer/nmixer.cc
@@ -216,7 +216,7 @@ NMixer::DrawScrollbar(short i, int spos)
 		mvwprintw(mixwin, my_y + 1, my_x, (char*)empty_scrollbar);
 	
 		//draw new bar
-		mvwprintw(mixwin, my_y - 1, my_x, (char*)source);
+		mvwprintw(mixwin, my_y - 1, my_x, "%s", (char*)source);
 		if (i == currentbar)
 		{
 			mvwchgat(mixwin, my_y - 1, my_x, strlen(source), A_REVERSE, 


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    nmixer.cc:219:26: error: format not a string literal and no format arguments [-Werror=format-security]
      219 |                 mvwprintw(mixwin, my_y - 1, my_x, (char*)source);
          |                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Let's wrap all the missing places with "%s" format.